### PR TITLE
Cancer Hotspots support

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -39,12 +39,22 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-tomcat</artifactId>
       <scope>provided</scope>
       </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-mongodb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.2</version>
     </dependency>
     <dependency>
       <groupId>io.springfox</groupId>

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/Hotspot.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/Hotspot.java
@@ -32,9 +32,15 @@
 
 package org.cbioportal.genome_nexus.annotation.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModelProperty;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
 
+@Document(collection = "hotspots")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Hotspot
 {
     @Id

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/Hotspot.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/Hotspot.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal Genome Nexus.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.genome_nexus.annotation.domain;
+
+import org.springframework.data.annotation.Id;
+
+public class Hotspot
+{
+    @Id
+    private String transcriptId;
+}

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/Hotspot.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/Hotspot.java
@@ -43,6 +43,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Hotspot
 {
+    // TODO transcriptId is not a unique identifier, we may need a composite id...
     @Id
     private String transcriptId;
 

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/Hotspot.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/Hotspot.java
@@ -32,10 +32,84 @@
 
 package org.cbioportal.genome_nexus.annotation.domain;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.springframework.data.annotation.Id;
 
 public class Hotspot
 {
     @Id
     private String transcriptId;
+
+    private String hugoSymbol;
+    private String residue;
+
+    private String proteinStart;
+    private String proteinEnd;
+    private String geneId;
+
+    @ApiModelProperty(value = "Transcript id", required = true)
+    public String getTranscriptId()
+    {
+        return transcriptId;
+    }
+
+    public void setTranscriptId(String transcriptId)
+    {
+        this.transcriptId = transcriptId;
+    }
+
+    @ApiModelProperty(value = "Protein start position", required = false)
+    public String getProteinStart()
+    {
+        return proteinStart;
+    }
+
+    public void setProteinStart(String proteinStart)
+    {
+        this.proteinStart = proteinStart;
+    }
+
+    @ApiModelProperty(value = "Protein end position", required = false)
+    public String getProteinEnd()
+    {
+        return proteinEnd;
+    }
+
+    public void setProteinEnd(String proteinEnd)
+    {
+        this.proteinEnd = proteinEnd;
+    }
+
+    @ApiModelProperty(value = "Ensembl gene id", required = false)
+    public String getGeneId()
+    {
+        return geneId;
+    }
+
+    public void setGeneId(String geneId)
+    {
+        this.geneId = geneId;
+    }
+
+    @ApiModelProperty(value = "Hugo gene symbol", required = false)
+    public String getHugoSymbol()
+    {
+        return hugoSymbol;
+    }
+
+    public void setHugoSymbol(String hugoSymbol)
+    {
+        this.hugoSymbol = hugoSymbol;
+    }
+
+    @ApiModelProperty(value = "Hotspot Residue", required = false)
+    public String getResidue()
+    {
+        return residue;
+    }
+
+    public void setResidue(String residue)
+    {
+        this.residue = residue;
+    }
 }

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/HotspotRepository.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/HotspotRepository.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal Genome Nexus.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.genome_nexus.annotation.domain;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+/**
+ * @author Selcuk Onur Sumer
+ */
+public interface HotspotRepository extends MongoRepository<Hotspot, String> {}

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/internal/VariantAnnotationRepositoryImpl.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/internal/VariantAnnotationRepositoryImpl.java
@@ -83,6 +83,7 @@ public class VariantAnnotationRepositoryImpl implements VariantAnnotationReposit
     public VariantAnnotation mapAnnotationJson(String variant, String annotationJSON) throws IOException
     {
         //String toMap = removeArrayBrackets(annotationJSON);
+        // TODO use Transformer.converToDbObject instead and remove the private function of this class
         String toMap = JSON.serialize(convertToDbObject(annotationJSON));
 
         VariantAnnotation vepVariantAnnotation;

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/HotspotService.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/HotspotService.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal Genome Nexus.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.genome_nexus.annotation.service;
+
+import org.cbioportal.genome_nexus.annotation.domain.Hotspot;
+
+import java.util.List;
+
+/**
+ * @author Selcuk Onur Sumer
+ */
+public interface HotspotService
+{
+    List<Hotspot> getHotspots(String transcriptId);
+    List<Hotspot> getHotspots();
+}

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/internal/CancerHotspotService.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/internal/CancerHotspotService.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal Genome Nexus.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.genome_nexus.annotation.service.internal;
+
+import org.cbioportal.genome_nexus.annotation.domain.Hotspot;
+import org.cbioportal.genome_nexus.annotation.service.HotspotService;
+import org.cbioportal.genome_nexus.annotation.util.Transformer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Selcuk Onur Sumer
+ */
+@Service
+public class CancerHotspotService implements HotspotService
+{
+    private String hotspotsURL;
+    @Value("${hotspots.url}")
+    public void setHotspotsURL(String hotspotsURL) { this.hotspotsURL = hotspotsURL; }
+
+
+    @Override
+    public List<Hotspot> getHotspots(String transcriptId)
+    {
+        try
+        {
+            return Transformer.mapJsonToInstance(getHotspotsJSON(transcriptId), Hotspot.class);
+        }
+        catch (IOException e)
+        {
+            e.printStackTrace();
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public List<Hotspot> getHotspots()
+    {
+        try
+        {
+            return Transformer.mapJsonToInstance(getHotspotsJSON(null), Hotspot.class);
+        }
+        catch (IOException e)
+        {
+            e.printStackTrace();
+            return Collections.emptyList();
+        }
+    }
+
+    private String getHotspotsJSON(String variables)
+    {
+        String uri = hotspotsURL;
+
+        if (variables != null &&
+            variables.length() > 0)
+        {
+            uri += "/" + variables;
+        }
+
+        RestTemplate restTemplate = new RestTemplate();
+        return restTemplate.getForObject(uri, String.class);
+    }
+}

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/internal/HotspotCache.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/internal/HotspotCache.java
@@ -33,73 +33,29 @@
 package org.cbioportal.genome_nexus.annotation.service.internal;
 
 import org.cbioportal.genome_nexus.annotation.domain.Hotspot;
-import org.cbioportal.genome_nexus.annotation.service.HotspotService;
-import org.cbioportal.genome_nexus.annotation.util.Transformer;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
+ * In-memory cache for hotspot mutations for better performance.
+ *
  * @author Selcuk Onur Sumer
  */
-@Service
-public class CancerHotspotService implements HotspotService
+public class HotspotCache
 {
-    // TODO make the cache functional
-    private HotspotCache cache;
+    private List<Hotspot> hotspots;
+    private Map<String, List<Hotspot>> mapByTranscript;
 
-    private String hotspotsURL;
-    @Value("${hotspots.url}")
-    public void setHotspotsURL(String hotspotsURL) { this.hotspotsURL = hotspotsURL; }
-
-    public CancerHotspotService()
+    public HotspotCache()
     {
-        this.cache = new HotspotCache();
+        this(null);
     }
 
-    @Override
-    public List<Hotspot> getHotspots(String transcriptId)
+    public HotspotCache(List<Hotspot> hotspots)
     {
-        try
-        {
-            return Transformer.mapJsonToInstance(getHotspotsJSON(transcriptId), Hotspot.class);
-        }
-        catch (IOException e)
-        {
-            e.printStackTrace();
-            return Collections.emptyList();
-        }
+        this.hotspots = hotspots;
     }
 
-    @Override
-    public List<Hotspot> getHotspots()
-    {
-        try
-        {
-            return Transformer.mapJsonToInstance(getHotspotsJSON(null), Hotspot.class);
-        }
-        catch (IOException e)
-        {
-            e.printStackTrace();
-            return Collections.emptyList();
-        }
-    }
-
-    private String getHotspotsJSON(String variables)
-    {
-        String uri = hotspotsURL;
-
-        if (variables != null &&
-            variables.length() > 0)
-        {
-            uri += "/" + variables;
-        }
-
-        RestTemplate restTemplate = new RestTemplate();
-        return restTemplate.getForObject(uri, String.class);
-    }
+    // TODO make the cache functional!
 }

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/internal/HotspotCache.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/internal/HotspotCache.java
@@ -34,8 +34,7 @@ package org.cbioportal.genome_nexus.annotation.service.internal;
 
 import org.cbioportal.genome_nexus.annotation.domain.Hotspot;
 
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * In-memory cache for hotspot mutations for better performance.
@@ -55,7 +54,53 @@ public class HotspotCache
     public HotspotCache(List<Hotspot> hotspots)
     {
         this.hotspots = hotspots;
+        this.mapByTranscript = initMapByTranscript(hotspots);
     }
 
-    // TODO make the cache functional!
+    public List<Hotspot> findByTranscriptId(String transcriptId)
+    {
+        List<Hotspot> hotspots = null;
+
+        if (transcriptId != null)
+        {
+            hotspots = mapByTranscript.get(transcriptId.toLowerCase());
+        }
+
+        if (hotspots == null)
+        {
+            hotspots = Collections.emptyList();
+        }
+
+        return hotspots;
+    }
+
+    private Map<String, List<Hotspot>> initMapByTranscript(List<Hotspot> hotspots)
+    {
+        if (hotspots == null)
+        {
+            return Collections.emptyMap();
+        }
+
+        Map<String, List<Hotspot>> map = new LinkedHashMap<>();
+
+        for (Hotspot hotspot : hotspots)
+        {
+            String transcriptId = hotspot.getTranscriptId();
+
+            if (transcriptId != null)
+            {
+                List<Hotspot> list = map.get(transcriptId.toLowerCase());
+
+                if (list == null)
+                {
+                    list = new LinkedList<>();
+                    map.put(transcriptId.toLowerCase(), list);
+                }
+
+                list.add(hotspot);
+            }
+        }
+
+        return map;
+    }
 }

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/util/Numerical.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/util/Numerical.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal Genome Nexus.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.genome_nexus.annotation.util;
+
+import org.apache.commons.lang.math.NumberRange;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Static Utility methods for numerical operations.
+ *
+ * @author Selcuk Onur Sumer
+ */
+public class Numerical
+{
+	/**
+     * Extracts positive integers from the given input string.
+     *
+     * @param input input string
+     * @return  list of integers
+     */
+    public static List<Integer> extractPositiveIntegers(String input)
+    {
+        if (input == null)
+        {
+            return Collections.emptyList();
+        }
+
+        List<Integer> list = new ArrayList<>();
+        Pattern p = Pattern.compile("\\d+");
+        Matcher m = p.matcher(input);
+
+        while (m.find()) {
+            list.add(Integer.parseInt(m.group()));
+        }
+
+        return list;
+    }
+
+	/**
+     * Checks if the given input value overlaps the start and end values.
+     * Input value can be a range value too.
+     *
+     * This function assumes that start value is smaller than the end value.
+     *
+     * @param input input string (a single value or a range value)
+     * @param start start value
+     * @param end   end value
+     * @return      true if there is an overlap between values
+     */
+    public static boolean overlaps(String input, String start, String end)
+    {
+        Integer startValue = null;
+        Integer endValue = null;
+        Integer minPos = null;
+        Integer maxPos = null;
+        boolean overlap = false;
+        List<Integer> positions = extractPositiveIntegers(input);
+
+        if (positions.size() > 0)
+        {
+            minPos = Collections.min(positions);
+            maxPos = Collections.max(positions);
+        }
+
+        if (end != null && end.matches("\\d+")) {
+            endValue = Integer.parseInt(end);
+        }
+
+        if (start != null && start.matches("\\d+")) {
+            startValue = Integer.parseInt(start);
+        }
+
+        NumberRange range;
+
+        if (startValue != null)
+        {
+            // if end value is not valid use start value as the end value
+            if (endValue == null || endValue < startValue) {
+                endValue = startValue;
+            }
+
+            range = new NumberRange(startValue, endValue);
+
+            // check for an overlap
+            if (range.containsNumber(minPos) ||
+                range.containsNumber(maxPos))
+            {
+                overlap = true;
+            }
+        }
+
+        // input can be a range value too!
+        if (minPos != null && maxPos != null)
+        {
+            range = new NumberRange(minPos, maxPos);
+
+            if (range.containsNumber(startValue) ||
+                range.containsNumber(endValue))
+            {
+                overlap = true;
+            }
+        }
+
+        return overlap;
+    }
+}

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/util/Transformer.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/util/Transformer.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal Genome Nexus.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.genome_nexus.annotation.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.DBObject;
+import com.mongodb.util.JSON;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Selcuk Onur Sumer
+ */
+public class Transformer
+{
+    /**
+     * Transforms the given jsonString into a list of DBObject instances.
+     *
+     * @param jsonString    json string
+     * @return List of DBObject instances
+     */
+    public static List<DBObject> convertToDbObject(String jsonString)
+    {
+        List<DBObject> dbObjects = new ArrayList<>();
+        DBObject dbObject = (DBObject) JSON.parse(jsonString);
+
+        // if it is a list, just add all into the list
+        if (dbObject instanceof List)
+        {
+            for (Object obj: ((List) dbObject))
+            {
+                dbObjects.add((DBObject) obj);
+            }
+        }
+        else
+        {
+            dbObjects.add(dbObject);
+        }
+
+        return dbObjects;
+    }
+
+    /**
+     * Maps the given raw JSON string onto the provided class instance.
+     *
+     * @param jsonString    raw JSON string
+     * @return a list of instances of the provided class
+     * @throws IOException
+     */
+    public static <T> List<T> mapJsonToInstance(String jsonString, Class<T> type) throws IOException
+    {
+        List<T> list = new ArrayList<>();
+
+        for (DBObject dbObject: convertToDbObject(jsonString))
+        {
+            String toMap = JSON.serialize(dbObject);
+            ObjectMapper mapper = new ObjectMapper();
+
+            // map json string onto the given class type
+            list.add(mapper.readValue(toMap, type));
+        }
+
+        return list;
+    }
+}

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/web/AnnotationController.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/web/AnnotationController.java
@@ -174,7 +174,7 @@ public class AnnotationController
             {
                 for (TranscriptConsequence transcript : variantAnnotation.getTranscriptConsequences())
                 {
-                    hotspots.addAll(getHotspotAnnotation(transcript.getTranscriptId()));
+                    hotspots.addAll(getHotspotAnnotation(transcript));
                 }
             }
         }
@@ -286,17 +286,28 @@ public class AnnotationController
         return isoformOverrideService.getIsoformOverride(source, transcriptId);
     }
 
-    private List<Hotspot> getHotspotAnnotation(String transcriptId)
+    private List<Hotspot> getHotspotAnnotation(TranscriptConsequence transcript)
     {
         List<Hotspot> hotspots;
         // TODO make sure that transcript ID is a unique identifier for a Hotspot,
         // otherwise we may like to find all hotspots corresponding to this transcript ID
+        String transcriptId = transcript.getTranscriptId();
         Hotspot hotspot = hotspotRepository.findOne(transcriptId);
 
         if (hotspot == null)
         {
             // get the hotspot(s) from the web service and save it to the DB
             hotspots = hotspotService.getHotspots(transcriptId);
+
+            // TODO use a JSON view instead of copying fields to another model?
+            // we have data duplication here...
+            for (Hotspot rawHotspot : hotspots)
+            {
+                rawHotspot.setGeneId(transcript.getGeneId());
+                rawHotspot.setProteinStart(transcript.getProteinStart());
+                rawHotspot.setProteinEnd(transcript.getProteinEnd());
+            }
+
             hotspotRepository.save(hotspots);
         }
         else

--- a/annotation/src/main/resources/application.properties
+++ b/annotation/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 vep.url=http://grch37.rest.ensembl.org/vep/human/hgvs/VARIANT?content-type=application/json&xref_refseq=1&ccds=1&canonical=1&domains=1&hgvs=1&numbers=1&protein=1
+hotspots.url=http://cancerhotspots.org/api/hotspots/single/
+vep.overrides_uris=uniprot=isoform_overrides_uniprot.txt,mskcc=isoform_overrides_at_mskcc.txt
 
 spring.data.mongodb.uri=

--- a/annotation/src/test/java/org/cbioportal/genmone_nexus/annotation/util/NumericalTest.java
+++ b/annotation/src/test/java/org/cbioportal/genmone_nexus/annotation/util/NumericalTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
+ * FOR A PARTICULAR PURPOSE. The software and documentation provided hereunder
+ * is on an "as is" basis, and Memorial Sloan-Kettering Cancer Center has no
+ * obligations to provide maintenance, support, updates, enhancements or
+ * modifications. In no event shall Memorial Sloan-Kettering Cancer Center be
+ * liable to any party for direct, indirect, special, incidental or
+ * consequential damages, including lost profits, arising out of the use of this
+ * software and its documentation, even if Memorial Sloan-Kettering Cancer
+ * Center has been advised of the possibility of such damage.
+ */
+
+/*
+ * This file is part of cBioPortal Genome Nexus.
+ *
+ * cBioPortal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package org.cbioportal.genmone_nexus.annotation.util;
+
+import org.cbioportal.genome_nexus.annotation.util.Numerical;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for Numerical utils.
+ *
+ * @author Selcuk Onur Sumer
+ */
+public class NumericalTest
+{
+    @Test
+    public void positiveIntegerExtractor()
+    {
+        List<Integer> result;
+        Iterator<Integer> iterator;
+
+        // test null
+        result = Numerical.extractPositiveIntegers(null);
+        assertEquals(0, result.size());
+
+        // test invalid string
+        result = Numerical.extractPositiveIntegers("I have no integers!");
+        assertEquals(0, result.size());
+
+        // test the single point input
+        result = Numerical.extractPositiveIntegers("V600");
+        iterator = result.iterator();
+
+        assertEquals(1, result.size());
+        assertEquals((Integer)600, iterator.next());
+
+        // test the range input
+        result = Numerical.extractPositiveIntegers("666-668");
+        iterator = result.iterator();
+
+        assertEquals(2, result.size());
+        assertEquals((Integer)666, iterator.next());
+        assertEquals((Integer)668, iterator.next());
+    }
+
+    @Test
+    public void overlaps()
+    {
+        assertTrue(Numerical.overlaps("667", "666", "668"));
+        assertTrue(Numerical.overlaps("667-700", "666", "668"));
+        assertTrue(Numerical.overlaps("660-667", "666", "668"));
+        assertTrue(Numerical.overlaps("668-680", "666", "668"));
+        assertTrue(Numerical.overlaps("600-666", "666", "668"));
+
+        assertFalse(Numerical.overlaps("777", "666", "668"));
+        assertFalse(Numerical.overlaps("700-707", "666", "668"));
+        assertFalse(Numerical.overlaps("600", "666", "668"));
+        assertFalse(Numerical.overlaps("600-606", "666", "668"));
+
+        assertTrue(Numerical.overlaps("665-669", "666", "668"));
+    }
+}


### PR DESCRIPTION
Added a new API (`/cancer_hotspots/{variants:.+}`) to query cancer hotspots web service.

This PR is intended to fix issue #18 

In order for this new API to work properly, `application.properties` should include a line like this:
`hotspots.url= http://cancerhotspots.org/api/hotspots/single/`
