### PR TITLE
Isoform Override API improvements

### DIFF
--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/IsoformOverrideRepoFactory.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/IsoformOverrideRepoFactory.java
@@ -1,5 +1,7 @@
 package org.cbioportal.genome_nexus.annotation.domain;
 
+import java.util.List;
+
 /**
  * @author Selcuk Onur Sumer
  */
@@ -12,4 +14,11 @@ public interface IsoformOverrideRepoFactory
      * @return an IsoformOverrideRepository instance
      */
     IsoformOverrideRepository getRepository(String id);
+
+	/**
+     * Returns the list of all available isoform override data source names.
+     *
+     * @return list of available override sources
+     */
+    List<String> getOverrideSources();
 }

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/internal/IsoformOverrideRepoFactoryImpl.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/internal/IsoformOverrideRepoFactoryImpl.java
@@ -45,7 +45,7 @@ public class IsoformOverrideRepoFactoryImpl implements IsoformOverrideRepoFactor
 
         for (String pair: overrideURIs.split(","))
         {
-            String parts[] = pair.split("=");
+            String parts[] = pair.split(":");
 
             if (parts.length > 1)
             {

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/internal/IsoformOverrideRepoFactoryImpl.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/internal/IsoformOverrideRepoFactoryImpl.java
@@ -6,8 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * @author Selcuk Onur Sumer
@@ -64,6 +63,17 @@ public class IsoformOverrideRepoFactoryImpl implements IsoformOverrideRepoFactor
     public IsoformOverrideRepository getRepository(String id)
     {
         return getOverrideRepositories().get(id);
+    }
+
+    @Override
+    public List<String> getOverrideSources()
+    {
+        if (overrideRepositories != null)
+        {
+            return new ArrayList<>(overrideRepositories.keySet());
+        }
+
+        return Collections.emptyList();
     }
 
     public Map<String, IsoformOverrideRepository> getOverrideRepositories()

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/IsoformOverrideService.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/IsoformOverrideService.java
@@ -11,5 +11,6 @@ public interface IsoformOverrideService
 {
     IsoformOverride getIsoformOverride(String source, String id);
     List<IsoformOverride> getIsoformOverrides(String source);
+    List<String> getOverrideSources();
     Boolean hasData(String source);
 }

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/internal/VEPIsoformOverrideService.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/internal/VEPIsoformOverrideService.java
@@ -54,6 +54,11 @@ public class VEPIsoformOverrideService implements IsoformOverrideService
         }
     }
 
+    public List<String> getOverrideSources()
+    {
+        return repoFactory.getOverrideSources();
+    }
+
     @Override
     public Boolean hasData(String source)
     {

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/web/AnnotationController.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/web/AnnotationController.java
@@ -225,6 +225,32 @@ public class AnnotationController
         return isoformOverrideService.getIsoformOverrides(source);
     }
 
+    @ApiOperation(value = "getIsoformOverrideSources",
+        nickname = "getIsoformOverrideSources")
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Success",
+            response = IsoformOverride.class,
+            responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Bad Request")
+    })
+    @RequestMapping(value = "/isoform_override/sources",
+        method = RequestMethod.GET,
+        produces = "application/json")
+    public List<String> getIsoformOverrideSources()
+    {
+        return isoformOverrideService.getOverrideSources();
+    }
+
+    @ApiOperation(value = "postIsoformOverrideSources",
+        nickname = "postIsoformOverrideSources")
+    @RequestMapping(value = "/isoform_override/sources",
+        method = RequestMethod.POST,
+        produces = "application/json")
+    public List<String> postIsoformOverrideSources()
+    {
+        return getIsoformOverrideSources();
+    }
+
     private IsoformOverride getIsoformOverride(String source, String transcriptId)
     {
         return isoformOverrideService.getIsoformOverride(source, transcriptId);


### PR DESCRIPTION
- Added an API method to list all available isoform override data sources. (fixes #21)
- Updated isoform override uri resource delimiter. Now using semicolon instead of equals: `vep.overrides_uris=uniprot:isoform_overrides_uniprot.txt,mskcc:isoform_overrides_at_mskcc.txt`