### PR TITLE
Optional cancer hotspots information for VEP annotation

### DIFF
--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/TranscriptConsequence.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/TranscriptConsequence.java
@@ -32,13 +32,13 @@
 
 package org.cbioportal.genome_nexus.annotation.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import io.swagger.annotations.ApiModelProperty;
 import org.springframework.data.mongodb.core.mapping.Field;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Selcuk Onur Sumer
@@ -47,23 +47,26 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class TranscriptConsequence
 {
-    String transcriptId;
+    private String transcriptId;
 
-    String hgvsp;
-    String hgvsc;
-    String variantAllele;
-    String codons;
-    String proteinId;
-    String proteinStart;
-    String proteinEnd;
-    String geneSymbol;
-    String geneId;
-    String aminoAcids;
-    String hgncId;
-    String canonical;
+    private String hgvsp;
+    private String hgvsc;
+    private String variantAllele;
+    private String codons;
+    private String proteinId;
+    private String proteinStart;
+    private String proteinEnd;
+    private String geneSymbol;
+    private String geneId;
+    private String aminoAcids;
+    private String hgncId;
+    private String canonical;
 
-    List<String> refseqTranscriptIds;
-    List<String> consequenceTerms;
+    private List<String> refseqTranscriptIds;
+    private List<String> consequenceTerms;
+
+    @JsonIgnore
+    private Map<String, Object> dynamicProps;
 
     public TranscriptConsequence()
     {
@@ -73,6 +76,7 @@ public class TranscriptConsequence
     public TranscriptConsequence(String transcriptId)
     {
         this.transcriptId = transcriptId;
+        this.dynamicProps = new LinkedHashMap<>();
     }
 
     @Field(value="transcript_id")
@@ -268,5 +272,21 @@ public class TranscriptConsequence
     public void setConsequenceTerms(List<String> consequenceTerms)
     {
         this.consequenceTerms = consequenceTerms;
+    }
+
+    // this is to dynamically add additional properties for this transcript
+    // anything added into the dynamic props map will be returned as an additional
+    // json property
+
+    @JsonAnySetter
+    public void setDynamicProp(String key, Object value)
+    {
+        this.dynamicProps.put(key, value);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getDynamicProps()
+    {
+        return this.dynamicProps;
     }
 }

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/HotspotService.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/HotspotService.java
@@ -33,6 +33,7 @@
 package org.cbioportal.genome_nexus.annotation.service;
 
 import org.cbioportal.genome_nexus.annotation.domain.Hotspot;
+import org.cbioportal.genome_nexus.annotation.domain.TranscriptConsequence;
 
 import java.util.List;
 
@@ -42,5 +43,6 @@ import java.util.List;
 public interface HotspotService
 {
     List<Hotspot> getHotspots(String transcriptId);
+    List<Hotspot> getHotspots(TranscriptConsequence transcript);
     List<Hotspot> getHotspots();
 }

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/internal/HotspotAnnotationEnricher.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/service/internal/HotspotAnnotationEnricher.java
@@ -1,0 +1,63 @@
+package org.cbioportal.genome_nexus.annotation.service.internal;
+
+import org.cbioportal.genome_nexus.annotation.domain.Hotspot;
+import org.cbioportal.genome_nexus.annotation.domain.TranscriptConsequence;
+import org.cbioportal.genome_nexus.annotation.domain.VariantAnnotation;
+import org.cbioportal.genome_nexus.annotation.service.AnnotationEnricher;
+import org.cbioportal.genome_nexus.annotation.service.HotspotService;
+
+import java.util.List;
+
+/**
+ * @author Selcuk Onur Sumer
+ */
+public class HotspotAnnotationEnricher implements AnnotationEnricher
+{
+    private HotspotService hotspotService;
+    private Boolean fullInfo;
+
+    public HotspotAnnotationEnricher(HotspotService hotspotService)
+    {
+        this(hotspotService, false);
+    }
+
+    public HotspotAnnotationEnricher(HotspotService hotspotService, Boolean fullInfo)
+    {
+        this.hotspotService = hotspotService;
+        this.fullInfo = fullInfo;
+    }
+
+    @Override
+    public void enrich(VariantAnnotation annotation)
+    {
+        if (annotation.getTranscriptConsequences() != null)
+        {
+            for (TranscriptConsequence transcript : annotation.getTranscriptConsequences())
+            {
+                List<Hotspot> hotspots = hotspotService.getHotspots(transcript);
+
+                if (fullInfo) {
+                    enrichWithFullInfo(transcript, hotspots);
+                }
+                else {
+                    enrichWithSummary(transcript, hotspots);
+                }
+            }
+        }
+    }
+
+    private void enrichWithSummary(TranscriptConsequence transcript, List<Hotspot> hotspots)
+    {
+        // add a boolean field to the transcript
+        transcript.setDynamicProp("isHotspot", hotspots.size() > 0);
+    }
+
+    private void enrichWithFullInfo(TranscriptConsequence transcript, List<Hotspot> hotspots)
+    {
+        // attach the full list of hotspots
+        if (hotspots.size() > 0)
+        {
+            transcript.setDynamicProp("hotspots", hotspots);
+        }
+    }
+}

--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/web/AnnotationController.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/web/AnnotationController.java
@@ -34,11 +34,11 @@ package org.cbioportal.genome_nexus.annotation.web;
 
 import io.swagger.annotations.*;
 import org.cbioportal.genome_nexus.annotation.domain.*;
+import org.cbioportal.genome_nexus.annotation.service.internal.HotspotAnnotationEnricher;
 import org.cbioportal.genome_nexus.annotation.service.internal.IsoformAnnotationEnricher;
 import org.cbioportal.genome_nexus.annotation.service.*;
 
 import org.cbioportal.genome_nexus.annotation.service.internal.VEPEnrichmentService;
-import org.cbioportal.genome_nexus.annotation.util.Numerical;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.client.HttpClientErrorException;
@@ -95,7 +95,13 @@ public class AnnotationController
         @RequestParam(required = false)
         @ApiParam(value="Isoform override source. For example uniprot",
             required = false)
-        String isoformOverrideSource)
+        String isoformOverrideSource,
+        @RequestParam(required = false)
+        @ApiParam(value="Indicates whether to include cancer hotspots information. " +
+                        "Valid options are: summary, and full. " +
+                        "Any other value will be ignored.",
+            required = false)
+        String cancerHotspots)
 	{
 		List<VariantAnnotation> variantAnnotations = new ArrayList<>();
 
@@ -112,6 +118,15 @@ public class AnnotationController
                 isoformOverrideSource, isoformOverrideService);
 
             postEnrichmentService.registerEnricher(isoformOverrideSource, enricher);
+        }
+
+        // ignore any other value than "full" or "summary"
+        if (cancerHotspots != null &&
+            (cancerHotspots.equalsIgnoreCase("full") || cancerHotspots.equalsIgnoreCase("summary")))
+        {
+            AnnotationEnricher enricher = new HotspotAnnotationEnricher(
+                hotspotService, cancerHotspots.equalsIgnoreCase("full"));
+            postEnrichmentService.registerEnricher("cancerHotspots", enricher);
         }
 
 		for (String variant: variants)
@@ -142,9 +157,15 @@ public class AnnotationController
         @RequestParam(required = false)
         @ApiParam(value="Isoform override source. For example uniprot",
             required = false)
-        String isoformOverrideSource)
+        String isoformOverrideSource,
+        @RequestParam(required = false)
+        @ApiParam(value="Indicates whether to include cancer hotspots information. " +
+                        "Valid options are: summary, and full. " +
+                        "Any other value will be ignored.",
+            required = false)
+        String cancerHotspots)
     {
-       return getVariantAnnotation(variants, isoformOverrideSource);
+       return getVariantAnnotation(variants, isoformOverrideSource, cancerHotspots);
     }
 
     @ApiOperation(value = "getHotspotAnnotation",
@@ -165,7 +186,7 @@ public class AnnotationController
             allowMultiple = true)
         List<String> variants)
     {
-        List<VariantAnnotation> variantAnnotations = getVariantAnnotation(variants, null);
+        List<VariantAnnotation> variantAnnotations = getVariantAnnotation(variants, null, null);
         List<Hotspot> hotspots = new ArrayList<>();
 
         for (VariantAnnotation variantAnnotation : variantAnnotations)
@@ -314,29 +335,14 @@ public class AnnotationController
 
     private List<Hotspot> getHotspotAnnotation(TranscriptConsequence transcript)
     {
-        List<Hotspot> hotspots = new ArrayList<>();
-        String transcriptId = transcript.getTranscriptId();
+        //String transcriptId = transcript.getTranscriptId();
         //Hotspot hotspot = hotspotRepository.findOne(transcriptId);
 
         // get the hotspot(s) from the web service
-        for (Hotspot hotspot : hotspotService.getHotspots(transcriptId))
-        {
-            if (Numerical.overlaps(hotspot.getResidue(),
-                       transcript.getProteinStart(),
-                       transcript.getProteinEnd()))
-            {
-                // TODO use a JSON view instead of copying fields to another model?
-                // we have data duplication here...
-                hotspot.setGeneId(transcript.getGeneId());
-                hotspot.setProteinStart(transcript.getProteinStart());
-                hotspot.setProteinEnd(transcript.getProteinEnd());
+        List<Hotspot> hotspots = hotspotService.getHotspots(transcript);
 
-                hotspots.add(hotspot);
-
-                // do not cache anything for now
-                //hotspotRepository.save(hotspots);
-            }
-        }
+        // do not cache anything for now
+        //hotspotRepository.save(hotspots);
 
         return hotspots;
     }


### PR DESCRIPTION
- added an enricher to add hotspot info into transcripts
- added an API parameter to optionally enable hotspot enrichment

example query: http://localhost/variant_annotation/hgvs/7:g.140453136A>T?isoformOverrideSource=uniprot&cancerHotspots=summary

Intended for the issue #29 