### PR TITLE
Change refseqTranscriptIds from List to String

### DIFF
--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/TranscriptConsequence.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/domain/TranscriptConsequence.java
@@ -62,7 +62,7 @@ public class TranscriptConsequence
     private String hgncId;
     private String canonical;
 
-    private List<String> refseqTranscriptIds;
+    private String refseqTranscriptIds;
     private List<String> consequenceTerms;
 
     @JsonIgnore
@@ -251,12 +251,12 @@ public class TranscriptConsequence
     @Field(value="refseq_transcript_ids")
     @JsonProperty(value="refseq_transcript_ids", required = true)
     @ApiModelProperty(value = "List of RefSeq transcript ids", required = false)
-    public List<String> getRefseqTranscriptIds()
+    public String getRefseqTranscriptIds()
     {
         return refseqTranscriptIds;
     }
 
-    public void setRefseqTranscriptIds(List<String> refseqTranscriptIds)
+    public void setRefseqTranscriptIds(String refseqTranscriptIds)
     {
         this.refseqTranscriptIds = refseqTranscriptIds;
     }


### PR DESCRIPTION
@onursumer 

VEP changed their model for this field. This change aligns GN to VEP.

When model changes happen in the future GN will need to handle it and hide this change from the model presented to clients.