### PR TITLE
Fixed VariantAnnotation object returned when  DataIntegrityViolationException thrown

### DIFF
--- a/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/web/AnnotationController.java
+++ b/annotation/src/main/java/org/cbioportal/genome_nexus/annotation/web/AnnotationController.java
@@ -382,6 +382,7 @@ public class AnnotationController
                     // this is thrown when the annotationJSON can't be stored by mongo
                     // due to the variant annotation key being too large to index
                     LOG.info(e.getLocalizedMessage());
+                    return variantAnnotation;
                 }
             }
             catch (HttpClientErrorException e) {


### PR DESCRIPTION
If a `DataIntegrityViolationException` is thrown then the `VariantAnnotation` object returned will be malformed because of the additional caught `HttpClientErrorException`, which will overwrite the annotationJSON used to construct the `VariantAnnotation` object. This makes Genome Nexus think that it failed to annotate a variant even when the hgvs variant used is valid and returns a valid response from the VEP server.

If the hgvs variant is valid and returns a valid response from VEP server then we still want to parse the annotationJSON into a`VariantAnnotation` object.

Instead of overwriting the annotationJSON with the `HttpClientErrorException` message, the `VariantAnnotation` object will now be returned early to prevent the overwrite from happening.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>